### PR TITLE
feat: use integers instead of string for accessible enum

### DIFF
--- a/android/src/main/cpp/cpp-adapter.cpp
+++ b/android/src/main/cpp/cpp-adapter.cpp
@@ -86,7 +86,7 @@ jstring string2jstring(JNIEnv *env, const std::string str) {
 bool setItem(
     const std::string key,
     const std::string value,
-    const std::string accessibleValue) {
+    const int accessibleValue) {
   JNIEnv *jniEnv = GetJniEnv();
   java_class = jniEnv->GetObjectClass(java_object);
   jmethodID setMethodID = jniEnv->GetMethodID(

--- a/cpp/SecureStorageHostObject.cpp
+++ b/cpp/SecureStorageHostObject.cpp
@@ -8,7 +8,7 @@ using namespace facebook;
 using namespace jsi;
 using namespace std;
 
-function<bool(const string, const string, const string)> _set;
+function<bool(const string, const string, const int)> _set;
 function<const string(const string)> _get;
 function<bool(const string)> _del;
 function<void()> _clearStorage;
@@ -25,13 +25,13 @@ jsi::Value generateJSError(jsi::Runtime &runtime, string errorMessage) {
 struct KeyValue {
   string key;
   string value;
-  string accessibleValue;
+  int accessibleValue;
 };
 
 void install(
     jsi::Runtime &runtime,
     shared_ptr<react::CallInvoker> jsCallInvoker,
-    function<bool(const string, const string, const string)> setItemFn,
+    function<bool(const string, const string, const int)> setItemFn,
     function<string(const string)> getItemFn,
     function<bool(const string)> delItemFn,
     function<void()> clearStorageFn,
@@ -58,8 +58,8 @@ void install(
 
     const std::string key = arguments[0].getString(runtime).utf8(runtime);
     const std::string value = arguments[1].getString(runtime).utf8(runtime);
-    const std::string accessible =
-        arguments[2].getString(runtime).utf8(runtime);
+    const int accessible =
+        arguments[2].getNumber();
     auto promise = runtime.global().getPropertyAsFunction(runtime, "Promise");
     return promise.callAsConstructor(
         runtime,
@@ -112,9 +112,8 @@ void install(
       const auto value =
           item.getProperty(runtime, "value").asString(runtime).utf8(runtime);
       const auto accessibleValue = item.getProperty(runtime, "accessibleValue")
-                                       .asString(runtime)
-                                       .utf8(runtime);
-      itemsArray.push_back({key, value, accessibleValue});
+            .getNumber();
+        itemsArray.push_back({key, value, static_cast<int>(accessibleValue)});
     }
 
     auto promise = runtime.global().getPropertyAsFunction(runtime, "Promise");

--- a/cpp/SecureStorageHostObject.h
+++ b/cpp/SecureStorageHostObject.h
@@ -9,7 +9,7 @@ using namespace std;
 void install(
     jsi::Runtime &rt,
     shared_ptr<react::CallInvoker> jsCallInvoker,
-    function<bool(const string, const string, const string)> setItemFn,
+    function<bool(const string, const string, const int)> setItemFn,
     function<string(const string)> getItemFn,
     function<bool(const string)> deleteItemFn,
     function<void()> clearStorageFn,

--- a/ios/SecureStorage.h
+++ b/ios/SecureStorage.h
@@ -8,7 +8,7 @@
 #import <Security/Security.h>
 #import <iostream>
 
-CFStringRef _accessibleValue(const std::string accessible);
+CFStringRef _accessibleValue(const int accessible);
 NSString *getServiceName();
 NSMutableDictionary *generateBaseQueryDictionary(const std::string key);
 void clearSecureStorage();
@@ -21,5 +21,5 @@ bool secureStorageHasItem(const std::string key);
 bool setSecureStorageItem(
     const std::string key,
     const std::string value,
-    const std::string accessibleValue);
+    const int accessibleValue);
 bool deleteSecureStorageItem(const std::string key);

--- a/ios/SecureStorage.mm
+++ b/ios/SecureStorage.mm
@@ -9,24 +9,36 @@
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
-CFStringRef _accessibleValue(const std::string accessible)
+typedef NS_ENUM(NSInteger, AccessibilityLevel) {
+    AccessibleWhenUnlocked = 0,
+    AccessibleAfterFirstUnlock,
+    AccessibleAlways,
+    AccessibleWhenPasscodeSetThisDeviceOnly,
+    AccessibleWhenUnlockedThisDeviceOnly,
+    AccessibleAfterFirstUnlockThisDeviceOnly,
+    AccessibleAlwaysThisDeviceOnly
+};
+
+CFStringRef _accessibleValue(const int accessible)
 {
-  NSString *accessibleNSString = [[NSString alloc] initWithUTF8String:accessible.c_str()];
-
-  NSDictionary *list = @{
-    @"AccessibleWhenUnlocked" : (__bridge id)kSecAttrAccessibleWhenUnlocked,
-    @"AccessibleAfterFirstUnlock" : (__bridge id)kSecAttrAccessibleAfterFirstUnlock,
-    @"AccessibleAlways" : (__bridge id)kSecAttrAccessibleAlways,
-    @"AccessibleWhenPasscodeSetThisDeviceOnly" :
-        (__bridge id)kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-    @"AccessibleWhenUnlockedThisDeviceOnly" :
-        (__bridge id)kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-    @"AccessibleAfterFirstUnlockThisDeviceOnly" :
-        (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-    @"AccessibleAlwaysThisDeviceOnly" : (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly
-  };
-
-  return (__bridge CFStringRef)list[accessibleNSString];
+  switch (accessible) {
+        case AccessibleWhenUnlocked:
+            return kSecAttrAccessibleWhenUnlocked;
+        case AccessibleAfterFirstUnlock:
+            return kSecAttrAccessibleAfterFirstUnlock;
+        case AccessibleAlways:
+            return kSecAttrAccessibleAlways;
+        case AccessibleWhenPasscodeSetThisDeviceOnly:
+            return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
+        case AccessibleWhenUnlockedThisDeviceOnly:
+            return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+        case AccessibleAfterFirstUnlockThisDeviceOnly:
+            return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+        case AccessibleAlwaysThisDeviceOnly:
+            return kSecAttrAccessibleAlwaysThisDeviceOnly;
+        default:
+            return kSecAttrAccessibleWhenUnlocked; // Default case
+    }
 }
 
 NSString *serviceName = nil;
@@ -181,7 +193,7 @@ bool secureStorageHasItem(const std::string key)
 bool setSecureStorageItem(
     const std::string key,
     const std::string value,
-    const std::string accessible)
+    const int accessible)
 {
   NSMutableDictionary *dictionary = generateBaseQueryDictionary(key);
   NSData *valueData = [NSData dataWithBytes:value.data() length:value.length()];

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "react": "*",
     "react-native": "*"
   },
+  "workspaces": [
+    "example"
+  ],
   "packageManager": "yarn@3.6.1",
   "jest": {
     "preset": "react-native",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,9 +1,9 @@
 export const enum ACCESSIBLE {
-  WHEN_UNLOCKED = 'AccessibleWhenUnlocked',
-  AFTER_FIRST_UNLOCK = 'AccessibleAfterFirstUnlock',
-  ALWAYS = 'AccessibleAlways',
-  WHEN_PASSCODE_SET_THIS_DEVICE_ONLY = 'AccessibleWhenPasscodeSetThisDeviceOnly',
-  WHEN_UNLOCKED_THIS_DEVICE_ONLY = 'AccessibleWhenUnlockedThisDeviceOnly',
-  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY = 'AccessibleAfterFirstUnlockThisDeviceOnly',
-  ALWAYS_THIS_DEVICE_ONLY = 'AccessibleAlwaysThisDeviceOnly',
+  WHEN_UNLOCKED = 0,
+  AFTER_FIRST_UNLOCK = 1,
+  ALWAYS = 2,
+  WHEN_PASSCODE_SET_THIS_DEVICE_ONLY = 3,
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY = 4,
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY = 5,
+  ALWAYS_THIS_DEVICE_ONLY = 6,
 }


### PR DESCRIPTION
## 📜 Description
Added using integers instead of string for Accessible enum, because integers take up less memory space in cpp and it's easier to send integers than long strings.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- modified ACCESSIBLE enum

## 🤔 How Has This Been Tested?

## 📝 Checklist

- [x] CI successfully passed