### PR TITLE
feat: improve setItem performance on iOS

### DIFF
--- a/cpp/SecureStorageHostObject.cpp
+++ b/cpp/SecureStorageHostObject.cpp
@@ -58,8 +58,7 @@ void install(
 
     const std::string key = arguments[0].getString(runtime).utf8(runtime);
     const std::string value = arguments[1].getString(runtime).utf8(runtime);
-    const int accessible =
-        arguments[2].getNumber();
+    const int accessible = arguments[2].getNumber();
     auto promise = runtime.global().getPropertyAsFunction(runtime, "Promise");
     return promise.callAsConstructor(
         runtime,
@@ -111,9 +110,9 @@ void install(
           item.getProperty(runtime, "key").asString(runtime).utf8(runtime);
       const auto value =
           item.getProperty(runtime, "value").asString(runtime).utf8(runtime);
-      const auto accessibleValue = item.getProperty(runtime, "accessibleValue")
-            .getNumber();
-        itemsArray.push_back({key, value, static_cast<int>(accessibleValue)});
+      const auto accessibleValue =
+          item.getProperty(runtime, "accessibleValue").getNumber();
+      itemsArray.push_back({key, value, static_cast<int>(accessibleValue)});
     }
 
     auto promise = runtime.global().getPropertyAsFunction(runtime, "Promise");

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1237,13 +1237,15 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-fast-secure-storage (0.1.0):
+  - react-native-fast-secure-storage (1.1.1):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
+    - React
+    - React-callinvoker
     - React-Core
     - React-debug
     - React-Fabric
@@ -1757,7 +1759,7 @@ SPEC CHECKSUMS:
   React-logger: 4072f39df335ca443932e0ccece41fbeb5ca8404
   React-Mapbuffer: 714f2fae68edcabfc332b754e9fbaa8cfc68fdd4
   React-microtasksnativemodule: 4943ad8f99be8ccf5a63329fa7d269816609df9e
-  react-native-fast-secure-storage: b35a04cf343717cd50d57280d16d1fd9f4c6afc6
+  react-native-fast-secure-storage: b7c5601cab320f0de24f0f2d0becfe84df0ef81e
   React-nativeconfig: 4a9543185905fe41014c06776bf126083795aed9
   React-NativeModulesApple: 0506da59fc40d2e1e6e12a233db5e81c46face27
   React-perflogger: 3bbb82f18e9ac29a1a6931568e99d6305ef4403b

--- a/ios/SecureStorage.mm
+++ b/ios/SecureStorage.mm
@@ -10,35 +10,35 @@
 #import <Security/Security.h>
 
 typedef NS_ENUM(NSInteger, AccessibilityLevel) {
-    AccessibleWhenUnlocked = 0,
-    AccessibleAfterFirstUnlock,
-    AccessibleAlways,
-    AccessibleWhenPasscodeSetThisDeviceOnly,
-    AccessibleWhenUnlockedThisDeviceOnly,
-    AccessibleAfterFirstUnlockThisDeviceOnly,
-    AccessibleAlwaysThisDeviceOnly
+  AccessibleWhenUnlocked = 0,
+  AccessibleAfterFirstUnlock,
+  AccessibleAlways,
+  AccessibleWhenPasscodeSetThisDeviceOnly,
+  AccessibleWhenUnlockedThisDeviceOnly,
+  AccessibleAfterFirstUnlockThisDeviceOnly,
+  AccessibleAlwaysThisDeviceOnly
 };
 
 CFStringRef _accessibleValue(const int accessible)
 {
   switch (accessible) {
-        case AccessibleWhenUnlocked:
-            return kSecAttrAccessibleWhenUnlocked;
-        case AccessibleAfterFirstUnlock:
-            return kSecAttrAccessibleAfterFirstUnlock;
-        case AccessibleAlways:
-            return kSecAttrAccessibleAlways;
-        case AccessibleWhenPasscodeSetThisDeviceOnly:
-            return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
-        case AccessibleWhenUnlockedThisDeviceOnly:
-            return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
-        case AccessibleAfterFirstUnlockThisDeviceOnly:
-            return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
-        case AccessibleAlwaysThisDeviceOnly:
-            return kSecAttrAccessibleAlwaysThisDeviceOnly;
-        default:
-            return kSecAttrAccessibleWhenUnlocked; // Default case
-    }
+    case AccessibleWhenUnlocked:
+      return kSecAttrAccessibleWhenUnlocked;
+    case AccessibleAfterFirstUnlock:
+      return kSecAttrAccessibleAfterFirstUnlock;
+    case AccessibleAlways:
+      return kSecAttrAccessibleAlways;
+    case AccessibleWhenPasscodeSetThisDeviceOnly:
+      return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
+    case AccessibleWhenUnlockedThisDeviceOnly:
+      return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+    case AccessibleAfterFirstUnlockThisDeviceOnly:
+      return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+    case AccessibleAlwaysThisDeviceOnly:
+      return kSecAttrAccessibleAlwaysThisDeviceOnly;
+    default:
+      return kSecAttrAccessibleWhenUnlocked; // Default case
+  }
 }
 
 NSString *serviceName = nil;
@@ -190,12 +190,12 @@ bool secureStorageHasItem(const std::string key)
   return status != errSecItemNotFound;
 }
 
-bool setSecureStorageItem(
-    const std::string key,
-    const std::string value,
-    const int accessible)
+bool setSecureStorageItem(const std::string key, const std::string value, const int accessible)
 {
   NSMutableDictionary *dictionary = generateBaseQueryDictionary(key);
+
+  SecItemDelete((CFDictionaryRef)dictionary);
+
   NSData *valueData = [NSData dataWithBytes:value.data() length:value.length()];
   CFStringRef accessibleValue = _accessibleValue(accessible);
   [dictionary setObject:valueData forKey:(id)kSecValueData];
@@ -203,20 +203,7 @@ bool setSecureStorageItem(
 
   OSStatus status = SecItemAdd((CFDictionaryRef)dictionary, NULL);
 
-  if (status == errSecSuccess) {
-    return true;
-  } else {
-    NSMutableDictionary *updateDictionary = [[NSMutableDictionary alloc] init];
-    [updateDictionary setObject:valueData forKey:(id)kSecValueData];
-    updateDictionary[(__bridge NSString *)kSecAttrAccessible] = (__bridge id)accessibleValue;
-    NSMutableDictionary *searchDictionary = generateBaseQueryDictionary(key);
-    OSStatus status =
-        SecItemUpdate((CFDictionaryRef)searchDictionary, (CFDictionaryRef)updateDictionary);
-
-    return status == errSecSuccess;
-  }
-
-  return true;
+  return status == errSecSuccess;
 }
 
 bool deleteSecureStorageItem(const std::string key)


### PR DESCRIPTION
## 📜 Description
In this update, I replaced the original approach of attempting an item add followed by a conditional update in case of failure with a simplified approach that deletes the existing item and then adds the new one. This refactor applies to secure storage management, specifically replacing the second code snippet (conditional logic) with the first code snippet (delete-then-add). 

**Before**: The code attempted to add an item using SecItemAdd(). If it failed due to the item already existing (e.g., status != errSecSuccess), it fell back to SecItemUpdate() to modify the existing item. This involved creating an additional updateDictionary and invoking SecItemUpdate(), increasing complexity and overhead.
**After**: The code now first deletes any existing item using SecItemDelete() and then unconditionally adds the new item using SecItemAdd(). This avoids the need for conditional checks and extra logic for updates.

Rationale for the Change:
Performance Optimization:

The previous code path had to handle two cases: adding a new item and updating an existing item. This resulted in multiple system calls (one for SecItemAdd() and one for SecItemUpdate() in case of failure), adding both complexity and time overhead.
By simplifying the flow to always delete the existing item first, we eliminate the need for conditionally updating the item. This reduces the number of operations and the need for additional dictionary manipulations.
Expected Performance Improvement: Fewer conditional checks and system calls should lead to faster execution, especially when items frequently exist and require updates.
Simplified Logic:

The new approach is more straightforward: instead of handling two separate cases (add vs. update), the logic always deletes and then adds the item. This reduces the cognitive load for anyone maintaining the code in the future, as the flow is linear and predictable.
Reduced Complexity:

In the original approach, failure of SecItemAdd() led to a fallback that required creating an updateDictionary and making a separate SecItemUpdate() call. This additional branching and dictionary creation added complexity and increased the risk of mistakes or maintenance issues.
The new approach avoids extra dictionary allocations and keeps the code simpler and more maintainable.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Performance comprassion

set 1000 items to secure storage

|**set 1000 items to secure storage** | create + update |  delete + create  |
| ------------- | ------------- | ------------- |
| average time:  | 2.259  |  1.892 |
| median time: | 2  | 2 |

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 Pro

## 📝 Checklist

- [X] CI successfully passed