### PR TITLE
Fix: hasItem method typo

### DIFF
--- a/android/src/main/cpp/cpp-adapter.cpp
+++ b/android/src/main/cpp/cpp-adapter.cpp
@@ -117,7 +117,7 @@ bool hasItem(const std::string key) {
   JNIEnv *jniEnv = GetJniEnv();
   java_class = jniEnv->GetObjectClass(java_object);
   jmethodID hasItemMethodID =
-      jniEnv->GetMethodID(java_class, "hasitem", "(Ljava/lang/String;)Z");
+      jniEnv->GetMethodID(java_class, "hasItem", "(Ljava/lang/String;)Z");
   jvalue params[1];
   params[0].l = string2jstring(jniEnv, key);
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,6 +13,7 @@ const testItems = new Array(100).fill(0).map((_, index) => {
 
 export default function App() {
   const [result, setResult] = useState<string | undefined>();
+  const [hasItem, setHasItem] = useState(false);
   const [text, setText] = useState('');
 
   const getTestValue = async () => {
@@ -44,6 +45,7 @@ export default function App() {
     <ScrollView contentContainerStyle={styles.container}>
       <Rectangle />
       <Text>{result}</Text>
+      <Text>{hasItem ? 'Item exists' : 'Item does not exist'}</Text>
       <TextInput
         style={{ height: 50, width: '100%' }}
         defaultValue={text}
@@ -76,6 +78,12 @@ export default function App() {
         onPress={async () => {
           await SecureStorage.removeItem('test');
           getTestValue();
+        }}
+      />
+      <Button
+        title="has item"
+        onPress={async () => {
+          setHasItem(await SecureStorage.hasItem('test'));
         }}
       />
     </ScrollView>


### PR DESCRIPTION
## 📜 Description
There was a typo in the JNI code related to the hasItem method. It caused a crash on android devices, so I fixed it and added an example for regression testing in the future.

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Pixel 3a emulator

## 📸 Screenshots (if appropriate):
before:


https://github.com/user-attachments/assets/0a16d014-ea62-4377-90da-a25e9091c7c2



after:


https://github.com/user-attachments/assets/7b1c7906-b449-4de6-95e4-f6a4910fec92


<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed