### PR TITLE
Compile the library having support for 16KB page size

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -30,6 +30,7 @@ set_target_properties(
 find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 find_library(log-lib log)
+target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   target_link_libraries(


### PR DESCRIPTION
## 📜 Description

To support compiling 16 KB-aligned shared libraries with Android NDK version r26 or lower, requires the configuration to be updated as described in https://developer.android.com/guide/practices/page-sizes#cmake

## 💡 Motivation and Context

https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

## 📢 Changelog
- Update `CMakeLists.txt` to enable 16 KB ELF alignment

### JS
- None

### iOS
- None

### Android

- Update `CMakeLists.txt` to enable 16 KB ELF alignment

## 🤔 How Has This Been Tested?

Built and compiled successful and tested in a production build

## 📸 Screenshots (if appropriate):

Check alignment using https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh

<img width="979" height="372" alt="fast-storage-alignment" src="https://github.com/user-attachments/assets/be62727e-62e4-4a79-a968-51d6d07e84d8" />


## 📝 Checklist

- None